### PR TITLE
chore: add Expo dependencies and scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "agenda-exora-web",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^53.0.0",
+    "react": "^19.0.0",
+    "react-native": "0.79.0",
+    "react-native-gesture-handler": "latest",
+    "react-native-reanimated": "latest",
+    "react-native-calendars": "latest",
+    "react-native-modal": "latest",
+    "dayjs": "latest"
+  }
+}


### PR DESCRIPTION
## Summary
- initialize package.json with Expo 53, React 19, and React Native 0.79
- add gesture handler, reanimated, calendars, modal, and dayjs dependencies
- include standard Expo start scripts

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68abb4f069b88329952853db90ebeefc