### PR TITLE
feat: scaffold nextjs pwa skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+DATABASE_URL="postgres://user:pass@localhost:5432/db"
+NEXTAUTH_SECRET="changeme"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.next
+.env
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-Agenda-exora-web
+# Agenda Exora Web
+
+PWA creada con Next.js 14, TypeScript y Tailwind CSS. Incluye autenticación con NextAuth y datos de citas mock.
+
+## Scripts
+- `pnpm dev` – desarrollo
+- `pnpm build` – build
+- `pnpm start` – producción
+- `pnpm lint` – lint
+- `pnpm test` – tests
+
+## Variables de entorno
+Crea un fichero `.env` basado en `.env.example`.
+
+## Datos
+Actualmente las citas se obtienen de un mock en `app/api/appointments/data.ts`. Sustituye esa lógica por la fuente real cuando esté disponible.
+
+## PWA
+Se incluye manifest y configuración de `next-pwa` para service worker y cacheo básico.

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useState } from 'react';
+import { z } from 'zod';
+import { signIn } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6),
+});
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [errors, setErrors] = useState<string | null>(null);
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    const data = { email: formData.get('email'), password: formData.get('password') };
+    const parse = schema.safeParse(data);
+    if (!parse.success) {
+      setErrors('Datos inválidos');
+      return;
+    }
+    const res = await signIn('credentials', {
+      email: parse.data.email,
+      password: parse.data.password,
+      redirect: false,
+    });
+    if (res?.ok) {
+      router.push('/');
+    } else {
+      setErrors('Credenciales incorrectas');
+    }
+  }
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-complement3 p-4">
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow w-full max-w-sm space-y-4">
+        <h1 className="text-2xl font-heading text-primary">Iniciar sesión</h1>
+        <label className="block">
+          <span className="text-sm">Email</span>
+          <input name="email" type="email" required className="mt-1 w-full border p-2 rounded" />
+        </label>
+        <label className="block">
+          <span className="text-sm">Contraseña</span>
+          <input name="password" type="password" required className="mt-1 w-full border p-2 rounded" />
+        </label>
+        {errors && <p className="text-secondary text-sm" role="alert">{errors}</p>}
+        <button type="submit" className="w-full bg-primary text-white py-2 rounded">Entrar</button>
+      </form>
+    </div>
+  );
+}

--- a/app/(private)/layout.tsx
+++ b/app/(private)/layout.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from 'react';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../api/auth/[...nextauth]/route';
+import { redirect } from 'next/navigation';
+
+export default async function PrivateLayout({ children }: { children: ReactNode }) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    redirect('/login');
+  }
+  return <>{children}</>;
+}

--- a/app/(private)/page.tsx
+++ b/app/(private)/page.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import DateHeader from '@/components/DateHeader';
+import CardCarousel from '@/components/CardCarousel';
+import NoData from '@/components/NoData';
+import useAppointments from '@/hooks/useAppointments';
+import { useSearchParams, useRouter } from 'next/navigation';
+import { parseISO, format } from '@/lib/date';
+
+export default function HomePage() {
+  const search = useSearchParams();
+  const router = useRouter();
+  const initial = search.get('date');
+  const [date, setDate] = useState(() => (initial ? parseISO(initial) : new Date()));
+
+  useEffect(() => {
+    localStorage.setItem('lastDate', date.toISOString().slice(0, 10));
+  }, [date]);
+
+  const iso = date.toISOString().slice(0, 10);
+  const { data, isLoading, mutate } = useAppointments(iso);
+
+  function handleChange(d: Date) {
+    setDate(d);
+    router.replace(`/?date=${d.toISOString().slice(0, 10)}`);
+  }
+
+  return (
+    <main className="p-4 space-y-4">
+      <DateHeader date={date} onChange={handleChange} />
+      {isLoading ? (
+        <p>Cargando...</p>
+      ) : data && data.length > 0 ? (
+        <CardCarousel appointments={data} onRefresh={mutate} />
+      ) : (
+        <NoData onPick={() => {}} />
+      )}
+    </main>
+  );
+}

--- a/app/api/appointments/[id]/no-show/route.ts
+++ b/app/api/appointments/[id]/no-show/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { appointments } from '../../data';
+
+export async function POST(_: Request, { params }: { params: { id: string } }) {
+  const appt = appointments.find((a) => a.id === params.id);
+  if (appt) {
+    appt.noShow = true;
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/appointments/data.ts
+++ b/app/api/appointments/data.ts
@@ -1,0 +1,28 @@
+import { Appointment } from '@/types';
+
+export const appointments: Appointment[] = [
+  {
+    id: '1',
+    clienteNombre: 'Juan',
+    clienteApellidos: 'Pérez',
+    telefono: '600000000',
+    servicio: 'Corte de cabello adulto',
+    variante: 'Degradado',
+    sucursal: 'Parets',
+    profesional: 'Luis',
+    fechaISO: '2025-08-25',
+    horaInicio: '10:00',
+    descuentos: ['Promo verano'],
+  },
+  {
+    id: '2',
+    clienteNombre: 'María',
+    clienteApellidos: 'López',
+    telefono: '600000001',
+    servicio: 'Afeitado',
+    sucursal: 'Lliçà',
+    profesional: 'Carlos',
+    fechaISO: '2025-08-25',
+    horaInicio: '11:00',
+  },
+];

--- a/app/api/appointments/route.ts
+++ b/app/api/appointments/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { appointments } from './data';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const date = searchParams.get('date');
+  if (!date) return NextResponse.json([]);
+  return NextResponse.json(appointments.filter((a) => a.fechaISO === date));
+}

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,28 @@
+import NextAuth from 'next-auth';
+import Credentials from 'next-auth/providers/credentials';
+
+export const authOptions = {
+  providers: [
+    Credentials({
+      credentials: {
+        email: {},
+        password: {},
+      },
+      authorize: async (credentials) => {
+        if (
+          credentials?.email === 'admin@example.com' &&
+          credentials.password === 'password'
+        ) {
+          return { id: '1', name: 'Admin', email: credentials.email };
+        }
+        return null;
+      },
+    }),
+  ],
+  session: { strategy: 'jwt' },
+  pages: { signIn: '/login' },
+};
+
+const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,18 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --color-primary: #555BF6;
+    --color-secondary: #FD778B;
+    --color-complement1: #FCFFA8;
+    --color-complement2: #B7F1F4;
+    --color-complement3: #D2E9FF;
+    --color-complement4: #02145C;
+  }
+}
+
+body {
+  @apply bg-white text-complement4 dark:bg-complement4 dark:text-white;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,27 @@
+import './globals.css';
+import type { Metadata } from 'next';
+import { Inter, Work_Sans } from 'next/font/google';
+
+const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
+const workSans = Work_Sans({ subsets: ['latin'], variable: '--font-worksans' });
+
+export const metadata: Metadata = {
+  title: 'Agenda Exora',
+  description: 'PWA Agenda',
+  manifest: '/manifest.webmanifest',
+  themeColor: '#555BF6',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="es-ES" className={`${inter.variable} ${workSans.variable}`}> 
+      <body className="font-sans bg-white text-complement4 dark:bg-complement4 dark:text-white">
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/components/AppointmentCard.tsx
+++ b/components/AppointmentCard.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { Appointment } from '@/types';
+
+interface Props {
+  appointment: Appointment;
+  onNoShow: (id: string) => void;
+}
+
+export default function AppointmentCard({ appointment, onNoShow }: Props) {
+  return (
+    <div className="bg-white rounded shadow p-4 w-72 flex-shrink-0">
+      <h2 className="font-heading text-lg text-primary">
+        {appointment.clienteNombre} {appointment.clienteApellidos}
+      </h2>
+      <p className="text-sm">{appointment.telefono}</p>
+      <p className="mt-2 font-medium">{appointment.servicio}</p>
+      {appointment.variante && <p className="text-sm">{appointment.variante}</p>}
+      <p className="text-sm">{appointment.sucursal}</p>
+      <p className="text-sm">{appointment.profesional}</p>
+      <p className="text-sm">
+        {appointment.fechaISO} {appointment.horaInicio}
+      </p>
+      {appointment.descuentos?.length && (
+        <div className="flex flex-wrap gap-1 mt-2">
+          {appointment.descuentos.map((d) => (
+            <span key={d} className="text-xs bg-complement2 px-2 py-0.5 rounded">
+              {d}
+            </span>
+          ))}
+        </div>
+      )}
+      {appointment.noShow && (
+        <span className="block mt-2 text-secondary font-bold">No show</span>
+      )}
+      <button
+        className="mt-4 w-full border border-secondary text-secondary py-1 rounded disabled:opacity-50"
+        disabled={appointment.noShow}
+        onClick={() => onNoShow(appointment.id)}
+      >
+        No se ha presentado a la cita
+      </button>
+    </div>
+  );
+}

--- a/components/CardCarousel.tsx
+++ b/components/CardCarousel.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useState } from 'react';
+import { motion } from 'framer-motion';
+import AppointmentCard from './AppointmentCard';
+import { Appointment } from '@/types';
+import { markNoShow } from '@/lib/api';
+
+interface Props {
+  appointments: Appointment[];
+  onRefresh: () => void;
+}
+
+export default function CardCarousel({ appointments, onRefresh }: Props) {
+  const [index, setIndex] = useState(0);
+  const width = 288; // w-72 + gap
+
+  async function handleNoShow(id: string) {
+    await markNoShow(id);
+    onRefresh();
+  }
+
+  return (
+    <div className="overflow-hidden">
+      <motion.div
+        className="flex gap-4"
+        drag="x"
+        dragConstraints={{ left: -(appointments.length - 1) * width, right: 0 }}
+        animate={{ x: -index * width }}
+        transition={{ type: 'spring', stiffness: 200, damping: 30 }}
+        onDragEnd={(_, info) => {
+          const offset = info.offset.x;
+          const velocity = info.velocity.x;
+          if (offset < -50 || velocity < -500) {
+            setIndex(Math.min(index + 1, appointments.length - 1));
+          } else if (offset > 50 || velocity > 500) {
+            setIndex(Math.max(index - 1, 0));
+          }
+        }}
+      >
+        {appointments.map((a) => (
+          <AppointmentCard key={a.id} appointment={a} onNoShow={handleNoShow} />
+        ))}
+      </motion.div>
+    </div>
+  );
+}

--- a/components/DateHeader.tsx
+++ b/components/DateHeader.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { formatHeaderDate } from '@/lib/date';
+
+interface Props {
+  date: Date;
+  onChange: (d: Date) => void;
+}
+
+export default function DateHeader({ date, onChange }: Props) {
+  function shift(days: number) {
+    const d = new Date(date);
+    d.setDate(d.getDate() + days);
+    onChange(d);
+  }
+  return (
+    <header className="flex items-center justify-between" aria-live="polite">
+      <button aria-label="Día anterior" onClick={() => shift(-1)} className="p-2">
+        ◀︎
+      </button>
+      <span className="font-heading text-lg">{formatHeaderDate(date)}</span>
+      <button aria-label="Día siguiente" onClick={() => shift(1)} className="p-2">
+        ▶︎
+      </button>
+    </header>
+  );
+}

--- a/components/DayPicker.tsx
+++ b/components/DayPicker.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { DayPicker } from 'react-day-picker';
+import 'react-day-picker/dist/style.css';
+import { es } from 'date-fns/locale';
+
+interface Props {
+  selected: Date;
+  onSelect: (d: Date) => void;
+}
+
+export default function DayPickerModal({ selected, onSelect }: Props) {
+  return (
+    <DayPicker mode="single" locale={es} selected={selected} onSelect={(d) => d && onSelect(d)} />
+  );
+}

--- a/components/NoData.tsx
+++ b/components/NoData.tsx
@@ -1,0 +1,14 @@
+interface Props {
+  onPick: () => void;
+}
+
+export default function NoData({ onPick }: Props) {
+  return (
+    <div className="text-center p-8">
+      <p className="mb-4">No hay citas para este día.</p>
+      <button onClick={onPick} className="text-primary underline">
+        Cambiar fecha
+      </button>
+    </div>
+  );
+}

--- a/hooks/useAppointments.ts
+++ b/hooks/useAppointments.ts
@@ -1,0 +1,15 @@
+'use client';
+
+import useSWR from 'swr';
+import { Appointment } from '@/types';
+import { fetcher } from '@/lib/api';
+
+export default function useAppointments(date: string) {
+  const { data, error, mutate } = useSWR<Appointment[]>(`/api/appointments?date=${date}`, fetcher);
+  return {
+    data,
+    isLoading: !data && !error,
+    isError: !!error,
+    mutate,
+  };
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,11 @@
+export async function fetcher(url: string) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error('Network error');
+  return res.json();
+}
+
+export async function markNoShow(id: string) {
+  const res = await fetch(`/api/appointments/${id}/no-show`, { method: 'POST' });
+  if (!res.ok) throw new Error('Network error');
+  return res.json();
+}

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -1,0 +1,14 @@
+import { format as f, parseISO as parseISODate } from 'date-fns';
+import { es } from 'date-fns/locale';
+
+export function formatHeaderDate(date: Date) {
+  return f(date, "EEEE, dd/MM/yyyy", { locale: es });
+}
+
+export function parseISO(str: string) {
+  return parseISODate(str);
+}
+
+export function format(date: Date, pattern: string) {
+  return f(date, pattern, { locale: es });
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,5 @@
+export { default } from 'next-auth/middleware';
+
+export const config = {
+  matcher: ['/((?!api|_next|login|manifest.webmanifest|icons).*)'],
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,18 @@
+import withPWA from 'next-pwa';
+
+const nextConfig = {
+  experimental: {
+    appDir: true,
+  },
+  i18n: {
+    locales: ['es-ES'],
+    defaultLocale: 'es-ES',
+  },
+};
+
+export default withPWA({
+  dest: 'public',
+  register: true,
+  skipWaiting: true,
+  disable: process.env.NODE_ENV === 'development',
+})(nextConfig);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "agenda-exora-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "next-auth": "5.0.0-beta.8",
+    "zod": "3.22.2",
+    "swr": "2.2.2",
+    "framer-motion": "10.16.4",
+    "react-day-picker": "8.8.3",
+    "tailwindcss": "3.4.1",
+    "autoprefixer": "10.4.16",
+    "postcss": "8.4.31",
+    "next-pwa": "5.6.0",
+    "@fortawesome/free-solid-svg-icons": "6.5.1",
+    "@fortawesome/react-fontawesome": "0.2.0",
+    "date-fns": "3.6.0"
+  },
+  "devDependencies": {
+    "typescript": "5.3.3",
+    "@types/node": "20.11.16",
+    "@types/react": "18.2.21",
+    "@types/react-dom": "18.2.7",
+    "eslint": "8.56.0",
+    "eslint-config-next": "14.1.0",
+    "prettier": "3.2.5",
+    "vitest": "1.3.1",
+    "@testing-library/react": "14.0.0",
+    "@testing-library/jest-dom": "6.2.3",
+    "jsdom": "23.0.1"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,8 @@
+{
+  "name": "Agenda Exora",
+  "short_name": "Agenda",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#FFFFFF",
+  "theme_color": "#555BF6"
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,25 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  darkMode: 'class',
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        primary: '#555BF6',
+        secondary: '#FD778B',
+        complement1: '#FCFFA8',
+        complement2: '#B7F1F4',
+        complement3: '#D2E9FF',
+        complement4: '#02145C',
+      },
+      fontFamily: {
+        sans: ['var(--font-inter)', 'sans-serif'],
+        heading: ['var(--font-worksans)', 'sans-serif'],
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/tests/date.test.ts
+++ b/tests/date.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { formatHeaderDate } from '../lib/date';
+
+describe('formatHeaderDate', () => {
+  it('formats correctly', () => {
+    const date = new Date('2025-08-25T00:00:00Z');
+    expect(formatHeaderDate(date)).toContain('25/08/2025');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/types.ts
+++ b/types.ts
@@ -1,0 +1,14 @@
+export type Appointment = {
+  id: string;
+  clienteNombre: string;
+  clienteApellidos: string;
+  telefono: string;
+  servicio: string;
+  variante?: string;
+  sucursal: string;
+  profesional: string;
+  fechaISO: string;
+  horaInicio: string;
+  descuentos?: string[];
+  noShow?: boolean;
+};


### PR DESCRIPTION
## Summary
- setup Next.js 14 app router with Tailwind, PWA manifest and brand tokens
- add mock appointments API and carousel with no-show action
- implement credential login with NextAuth and basic middleware
- remove binary icon assets and streamline manifest

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `pnpm build` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7259d5848329b75349143a633580