### PR TITLE
fix: use valid @testing-library/jest-dom version (^6.8.0) and clean reinstall

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prettier": "3.2.5",
     "vitest": "1.3.1",
     "@testing-library/react": "14.0.0",
-    "@testing-library/jest-dom": "6.2.3",
+    "@testing-library/jest-dom": "^6.8.0",
     "jsdom": "23.0.1"
   }
 }


### PR DESCRIPTION
## Summary
- use @testing-library/jest-dom ^6.8.0
- add .npmrc pointing to npmjs registry

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@fortawesome%2ffree-solid-svg-icons)*
- `npm view @testing-library/jest-dom versions --json | head -n 1 >/dev/null` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac79e34d54832988bad881d78e8595