### PR TITLE
fix: bump react-day-picker to ^9.9.0 and migrate minimal v9 API

### DIFF
--- a/components/DayPicker.tsx
+++ b/components/DayPicker.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { DayPicker } from 'react-day-picker';
-import 'react-day-picker/dist/style.css';
+import 'react-day-picker/style.css';
 import { es } from 'date-fns/locale';
 
 interface Props {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "zod": "3.22.2",
     "swr": "2.2.2",
     "framer-motion": "10.16.4",
-    "react-day-picker": "8.8.3",
+    "react-day-picker": "^9.9.0",
     "tailwindcss": "3.4.1",
     "autoprefixer": "10.4.16",
     "postcss": "8.4.31",


### PR DESCRIPTION
## Summary
- bump react-day-picker to ^9.9.0
- update DayPicker import to v9 style

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@fortawesome%2ffree-solid-svg-icons)
- `npm run build` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68ac7c5dc9bc8329a3dfc0dd7d5f439e