### PR TITLE
Replace auth middleware to avoid unsupported Edge modules

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,14 +1,19 @@
-import { auth } from "@/auth";
 import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { getToken } from "next-auth/jwt";
 
-export default auth((req) => {
+export async function middleware(req: NextRequest) {
   const { nextUrl } = req;
-  if (!req.auth) {
+  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+
+  if (!token) {
     const url = new URL("/login", nextUrl);
     url.searchParams.set("callbackUrl", nextUrl.pathname);
     return NextResponse.redirect(url);
   }
-});
+
+  return NextResponse.next();
+}
 
 export const config = {
   matcher: ['/((?!api|_next|login|manifest.webmanifest|icons).*)'],


### PR DESCRIPTION
## Summary
- refactor middleware to use `next-auth/jwt` for token checking instead of importing the main auth module

## Testing
- `npm test` *(fails: vitest not found, dependency installation blocked)*


------
https://chatgpt.com/codex/tasks/task_e_68ac886589c88329a517d9625af6e8f0