### PR TITLE
fix: safe auth middleware scoped to /(private) + health endpoint + node runtime for auth route

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,2 @@
-import { handlers } from "@/auth";
-
-export const { GET, POST } = handlers;
+export const runtime = "nodejs"; // el handler SÍ puede ir en Node si prefieres
+export { GET, POST } from "@/auth";

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,18 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  // NO devuelvas secretos, solo si existen o no
+  const hasSecret = Boolean(process.env.NEXTAUTH_SECRET);
+  const hasUrl = Boolean(process.env.NEXTAUTH_URL);
+
+  return NextResponse.json({
+    ok: true,
+    env: {
+      NEXTAUTH_SECRET: hasSecret ? "present" : "missing",
+      NEXTAUTH_URL: hasUrl ? "present" : "missing",
+    },
+    time: new Date().toISOString(),
+  });
+}

--- a/auth.ts
+++ b/auth.ts
@@ -33,3 +33,5 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   trustHost: true, // necesario en Vercel para callbacks correctos
   secret: process.env.NEXTAUTH_SECRET,
 });
+
+export const { GET, POST } = handlers;

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,20 +1,27 @@
 import { NextResponse } from "next/server";
-import type { NextRequest } from "next/server";
-import { getToken } from "next-auth/jwt";
+import { auth } from "@/auth";
 
-export async function middleware(req: NextRequest) {
-  const { nextUrl } = req;
-  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+// Middleware robusto: solo protege /(private) y nunca revienta la app.
+export default auth((req) => {
+  try {
+    const { nextUrl } = req;
 
-  if (!token) {
-    const url = new URL("/login", nextUrl);
-    url.searchParams.set("callbackUrl", nextUrl.pathname);
-    return NextResponse.redirect(url);
+    // Solo proteger rutas bajo /(private)
+    if (!req.auth && nextUrl.pathname.startsWith("/(private)")) {
+      const url = new URL("/login", nextUrl);
+      url.searchParams.set("callbackUrl", nextUrl.pathname);
+      return NextResponse.redirect(url);
+    }
+
+    return NextResponse.next();
+  } catch (err) {
+    // Nunca tirar 500 en middleware: log y continua
+    console.error("[MIDDLEWARE ERROR]", err);
+    return NextResponse.next();
   }
+});
 
-  return NextResponse.next();
-}
-
+// Ejecutar SOLO en /(private) (evita tocar /, /login, /api, _next, etc.)
 export const config = {
-  matcher: ['/((?!api|_next|login|manifest.webmanifest|icons).*)'],
+  matcher: ["/(private)(.*)"],
 };


### PR DESCRIPTION
## Summary
- scope auth middleware only to /(private) and avoid breaking on missing envs
- add health check endpoint exposing presence of NEXTAUTH env vars
- ensure auth route runs on Node runtime

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8fce053c8329868090b8214f8ee7