### PR TITLE
Validate appointment date query parameter

### DIFF
--- a/app/api/appointments/route.ts
+++ b/app/api/appointments/route.ts
@@ -1,9 +1,19 @@
 import { NextResponse } from 'next/server';
 import { appointments } from './data';
 
+/**
+ * Returns appointments for a given date.
+ *
+ * Query parameters:
+ * - `date`: ISO-8601 date string (e.g., 2025-08-25).
+ */
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const date = searchParams.get('date');
-  if (!date) return NextResponse.json([]);
+
+  if (!date || isNaN(Date.parse(date))) {
+    return NextResponse.json({ error: 'Missing date' }, { status: 400 });
+  }
+
   return NextResponse.json(appointments.filter((a) => a.fechaISO === date));
 }


### PR DESCRIPTION
## Summary
- validate appointments API date query and return 400 on missing/invalid values
- document expected `date` query parameter

## Testing
- `npm test`
- `npm run lint` *(fails: awaiting interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ac98696c9483299f1557b0ecd0b561