### PR TITLE
Handle missing appointments in no-show endpoint

### DIFF
--- a/app/api/appointments/[id]/no-show/route.ts
+++ b/app/api/appointments/[id]/no-show/route.ts
@@ -3,8 +3,9 @@ import { appointments } from '../../data';
 
 export async function POST(_: Request, { params }: { params: { id: string } }) {
   const appt = appointments.find((a) => a.id === params.id);
-  if (appt) {
-    appt.noShow = true;
+  if (!appt) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
   }
+  appt.noShow = true;
   return NextResponse.json({ ok: true });
 }


### PR DESCRIPTION
## Summary
- Return 404 with error when appointment is not found
- Only mark appointments as no-show if they exist

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68ac986b89d0832996a054aca97f0421