### PR TITLE
Handle errors when marking no shows

### DIFF
--- a/components/CardCarousel.tsx
+++ b/components/CardCarousel.tsx
@@ -16,8 +16,12 @@ export default function CardCarousel({ appointments, onRefresh }: Props) {
   const width = 288; // w-72 + gap
 
   async function handleNoShow(id: string) {
-    await markNoShow(id);
-    onRefresh();
+    try {
+      await markNoShow(id);
+      onRefresh();
+    } catch (e) {
+      alert('Failed to mark appointment as no show');
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- handle `markNoShow` errors and show alert on failure

## Testing
- `npm test`
- `npm run lint` *(fails: project not configured and prompts for setup)*

------
https://chatgpt.com/codex/tasks/task_e_68ac986f0f7c8329aded066f77af03ee