### PR TITLE
refactor: globalize DayPicker styles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,4 @@
+@import 'react-day-picker/dist/style.css';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/components/DayPicker.module.css
+++ b/components/DayPicker.module.css
@@ -1,0 +1,3 @@
+.container {
+  width: 100%;
+}

--- a/components/DayPicker.tsx
+++ b/components/DayPicker.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { DayPicker } from 'react-day-picker';
-import 'react-day-picker/dist/style.css';
 import { es } from 'date-fns/locale';
+import styles from './DayPicker.module.css';
 
 interface Props {
   selected: Date;
@@ -11,6 +11,13 @@ interface Props {
 
 export default function DayPickerModal({ selected, onSelect }: Props) {
   return (
-    <DayPicker mode="single" locale={es} selected={selected} onSelect={(d) => d && onSelect(d)} />
+    <div className={styles.container}>
+      <DayPicker
+        mode="single"
+        locale={es}
+        selected={selected}
+        onSelect={(d) => d && onSelect(d)}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- move `react-day-picker` stylesheet into global CSS entry
- scope DayPicker styles via CSS module

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9871a1b48329b35f981e53f87bef