### PR TITLE
feat: add robots.txt for indexing rules

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /api/
+


### PR DESCRIPTION
## Summary
- add robots.txt with indexing rules to disallow API crawling

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint configuration missing)*
- `npm run build` *(fails: network access for fonts)*
- `curl -I localhost:3000/robots.txt`


------
https://chatgpt.com/codex/tasks/task_e_68ac9f7abf288329a5637b531883c656