### PR TITLE
feat: enforce NextAuth env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ PWA creada con Next.js 14, TypeScript y Tailwind CSS. Incluye autenticación con
 
 ## Variables de entorno
 Crea un fichero `.env` basado en `.env.example`.
+Antes del despliegue asegúrate de definir las variables `NEXTAUTH_SECRET` y `NEXTAUTH_URL`,
+ya que la aplicación lanzará un error si faltan.
 
 ## Datos
 Actualmente las citas se obtienen de un mock en `app/api/appointments/data.ts`. Sustituye esa lógica por la fuente real cuando esté disponible.

--- a/auth.ts
+++ b/auth.ts
@@ -10,6 +10,14 @@ async function authenticateViaBackend(email: string, password: string) {
   return null;
 }
 
+if (!process.env.NEXTAUTH_SECRET) {
+  throw new Error("NEXTAUTH_SECRET no está definido en las variables de entorno");
+}
+
+if (!process.env.NEXTAUTH_URL) {
+  throw new Error("NEXTAUTH_URL no está definido en las variables de entorno");
+}
+
 export const { handlers, auth, signIn, signOut } = NextAuth({
   providers: [
     Credentials({


### PR DESCRIPTION
## Summary
- fail early when NEXTAUTH_SECRET or NEXTAUTH_URL env vars are missing
- document required NextAuth env vars

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aca863a96c83299ca394492e6ae6b9