### PR TITLE
Remove unused i18n config and add route prefix test

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,14 +1,6 @@
 import withPWA from 'next-pwa';
 
-const nextConfig = {
-  experimental: {
-    appDir: true,
-  },
-  i18n: {
-    locales: ['es-ES'],
-    defaultLocale: 'es-ES',
-  },
-};
+const nextConfig = {};
 
 export default withPWA({
   dest: 'public',

--- a/tests/language-prefix.test.ts
+++ b/tests/language-prefix.test.ts
@@ -1,0 +1,33 @@
+import { beforeAll, afterAll, describe, expect, test } from 'vitest';
+import next from 'next';
+import { createServer } from 'http';
+import type { AddressInfo } from 'net';
+
+let server: any;
+let baseUrl: string;
+
+describe('language prefix handling', () => {
+  beforeAll(async () => {
+    process.env.NEXT_DISABLE_FONT_DOWNLOADS = '1';
+    const app = next({ dev: true });
+    const handle = app.getRequestHandler();
+    await app.prepare();
+    server = createServer((req, res) => handle(req, res));
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const { port } = server.address() as AddressInfo;
+    baseUrl = `http://localhost:${port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  test(
+    'unknown locale prefix returns 404',
+    async () => {
+      const res = await fetch(`${baseUrl}/en`);
+      expect(res.status).toBe(404);
+    },
+    30000,
+  );
+});


### PR DESCRIPTION
## Summary
- drop unused i18n settings from Next.js config
- add Vitest check ensuring locale-prefixed routes return 404

## Testing
- `CI=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acadafd8d88329b2d57e745136f2cc