### PR TITLE
refactor: use relative redirect for home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,7 @@
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
-import { headers } from "next/headers";
 
 export default async function Home() {
   const session = await auth();
-  const url = headers().get("x-url") ?? process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3000";
-  const base = url.endsWith("/") ? url : `${url}/`;
-  const destination = new URL(session ? "agenda" : "login", base);
-  redirect(destination.toString());
+  redirect(session ? "/agenda" : "/login");
 }


### PR DESCRIPTION
## Summary
- refactor home page redirect to use relative paths without custom headers

## Testing
- `npm test` *(fails: Failed to fetch font `Work Sans` and `Inter`)*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68acb6a1d4e48329b6d638af60b8c5da