### PR TITLE
Fix login redirect to internal route

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -5,8 +5,7 @@ export default function LoginPage() {
     "use server";
     const email = String(formData.get("email") || "");
     const password = String(formData.get("password") || "");
-    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
-    const redirectTo = baseUrl ? new URL("/agenda", baseUrl).toString() : "/agenda";
+    const redirectTo = "/agenda";
     await signIn("credentials", { email, password, redirectTo });
   }
 


### PR DESCRIPTION
## Summary
- ensure login uses internal `/agenda` redirect instead of building from env

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68acb6a09e5c83299ff016910aa35bca